### PR TITLE
Inline keys

### DIFF
--- a/hls-proxy/bin/lib/process_argv.js
+++ b/hls-proxy/bin/lib/process_argv.js
@@ -30,6 +30,8 @@ try {
     "--cache-timeout":                        {num:  true},
     "--cache-key":                            {num:  true},
 
+    "--inline-keys":                          {bool: true},
+
     "-v":                                     {num:  true},
     "--acl-whitelist":                        {}
   }, true)
@@ -160,6 +162,7 @@ const bootstrap_server = function(start_server) {
     max_segments:   argv_vals["--max-segments"],
     cache_timeout:  argv_vals["--cache-timeout"],
     cache_key:      argv_vals["--cache-key"],
+    inline_keys:    argv_vals["--inline-keys"],
     verbosity:      argv_vals["-v"],
     acl_whitelist:  argv_vals["--acl-whitelist"]
   })

--- a/hls-proxy/segment_cache.js
+++ b/hls-proxy/segment_cache.js
@@ -1,4 +1,4 @@
-module.exports = function({should_prefetch_url, debug, debug_level, request, get_request_options, max_segments, cache_timeout, cache_key}) {
+module.exports = function({debug, debug_level, request, get_request_options, max_segments, cache_timeout, cache_key}) {
 
   // maps: "m3u8_url" => {access: timestamp, ts: []}
   const cache = {}
@@ -142,8 +142,6 @@ module.exports = function({should_prefetch_url, debug, debug_level, request, get
   }
 
   const prefetch_segment = function(m3u8_url, url, referer_url, dont_touch_access) {
-    if (! should_prefetch_url(url)) return
-
     if (cache[m3u8_url] === undefined) {
       // initialize a new data structure
       cache[m3u8_url] = {access: 0, ts: []}
@@ -204,8 +202,6 @@ module.exports = function({should_prefetch_url, debug, debug_level, request, get
   }
 
   const get_segment = function(url) {
-    if (! should_prefetch_url(url)) return undefined
-
     let debug_url = (debug_level >= 3) ? url : get_publickey_from_url(url)
 
     let segment = find_segment(url)
@@ -239,8 +235,6 @@ module.exports = function({should_prefetch_url, debug, debug_level, request, get
   }
 
   const add_listener = function(url, cb) {
-    if (! should_prefetch_url(url)) return false
-
     let debug_url = (debug_level >= 3) ? url : get_publickey_from_url(url)
 
     let segment = find_segment(url)

--- a/hls-proxy/servers/start_http.js
+++ b/hls-proxy/servers/start_http.js
@@ -2,13 +2,13 @@ const resolve = require('./lib/LAN_IPs').resolve
 const proxy   = require('../proxy')
 const http    = require('http')
 
-const start_server = function({host, port, req_headers, req_options, hooks, cache_segments, max_segments, cache_timeout, cache_key, verbosity, acl_whitelist}) {
+const start_server = function({host, port, req_headers, req_options, hooks, cache_segments, max_segments, cache_timeout, cache_key, inline_keys, verbosity, acl_whitelist}) {
   if (!port || isNaN(port)) port = 80
 
   resolve(host, port)
   .then((host) => {
     const server = http.createServer()
-    proxy({server, host, is_secure: false, req_headers, req_options, hooks, cache_segments, max_segments, cache_timeout, cache_key, debug_level: verbosity, acl_whitelist})
+    proxy({server, host, is_secure: false, req_headers, req_options, hooks, cache_segments, max_segments, cache_timeout, cache_key, inline_keys, debug_level: verbosity, acl_whitelist})
     server.listen(port, function () {
       console.log(`HTTP server is listening at: ${host}`)
     })

--- a/hls-proxy/servers/start_https.js
+++ b/hls-proxy/servers/start_https.js
@@ -3,7 +3,7 @@ const proxy   = require('../proxy')
 const https   = require('https')
 const fs      = require('fs')
 
-const start_server = function({host, port, req_headers, req_options, hooks, cache_segments, max_segments, cache_timeout, cache_key, verbosity, acl_whitelist}) {
+const start_server = function({host, port, req_headers, req_options, hooks, cache_segments, max_segments, cache_timeout, cache_key, inline_keys, verbosity, acl_whitelist}) {
   if (!port || isNaN(port)) port = 443
 
   resolve(host, port)
@@ -18,7 +18,7 @@ const start_server = function({host, port, req_headers, req_options, hooks, cach
     }
 
     const server = https.createServer(ssl_options)
-    proxy({server, host, is_secure: true, req_headers, req_options, hooks, cache_segments, max_segments, cache_timeout, cache_key, debug_level: verbosity, acl_whitelist})
+    proxy({server, host, is_secure: true, req_headers, req_options, hooks, cache_segments, max_segments, cache_timeout, cache_key, inline_keys, debug_level: verbosity, acl_whitelist})
     server.listen(port, function () {
       console.log(`HTTPS server is listening at: ${host}`)
     })


### PR DESCRIPTION
The inline-keys branch adds supports for inlining encryption keys as base64 data URIs in the m3u8 playlist.
This significantly reduces the number of HTTP requests required when playing back content and allows key data to be cached as well.

Example output

    #EXT-X-KEY:METHOD=AES-128,URI="data:;base64,pC09WSndrgA5Sz7fk/yk3Q==",IV=0x00000000000000000000000000000CE1
    #EXTINF:2.0480,
    http://127.0.0.1:7080/aHR0cH......

Changes made:

- Support of `--inline-keys` command line parameter, this requires `--cache-segments` as well to work
- Updated segment-cache.js to allow caching other URLs besides ".ts" URLs by default
- Updated proxy.js to handle lines with `#EXT-X-KEY:` for key injection